### PR TITLE
nix: fix name of built plugin file

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
           '';
           installPhase = ''
             mkdir -p $out/lib
-            cp Hyswipe.so $out/lib
+            cp Hyswipe.so $out/lib/libHyswipe.so
           '';
 
           meta = {


### PR DESCRIPTION
Apparently nix expects the shared object to be named a specific way. oops